### PR TITLE
Css flexible

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Default settings for the definitionlist plugin
+ */
+
+$conf['dt_fancy']  = false;

--- a/conf/default.php
+++ b/conf/default.php
@@ -4,3 +4,4 @@
  */
 
 $conf['dt_fancy']  = false;
+$conf['stylename'] = 'plugin_definitionlist';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Options for the defnitionlist plugin
+ */
+
+$meta['dt_fancy']  = array('onoff');

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -4,3 +4,4 @@
  */
 
 $meta['dt_fancy']  = array('onoff');
+$meta['stylename'] = array('string');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * English language file for definitionlist plugin
+ */
+
+$lang['dt_fancy']  = 'make content of dt tag enclosed between &lt;span class="term"&gt; and &lt;/span&gt;';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -4,3 +4,4 @@
  */
 
 $lang['dt_fancy']  = 'make content of dt tag enclosed between &lt;span class="term"&gt; and &lt;/span&gt;';
+$lang['stylename'] = 'default style class name for dl tag';

--- a/lang/ja/settings.php
+++ b/lang/ja/settings.php
@@ -4,3 +4,4 @@
  */
 
 $lang['dt_fancy']  = 'dtタグ内を &lt;span class="term"&gt; ～ &lt;/span&gt; で囲む';
+$lang['stylename'] = 'dlタグに適用するデフォルトスタイル名';

--- a/lang/ja/settings.php
+++ b/lang/ja/settings.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Japanese language file for definitionlist plugin
+ */
+
+$lang['dt_fancy']  = 'dtタグ内を &lt;span class="term"&gt; ～ &lt;/span&gt; で囲む';

--- a/style.css
+++ b/style.css
@@ -1,18 +1,18 @@
 /* plugin: definitionlist */
  
-dl, dt, dd {margin: 0; padding: 0}
+dl.plugin_definitionlist, dt, dd {margin: 0; padding: 0}
 
-dl {
+dl.plugin_definitionlist {
   font-size: 90%;
   padding-top: 1px;
 }
 
-html>body dl {
+html>body dl.plugin_definitionlist {
   padding-bottom: 0.5em;
   border-bottom: 1px dashed #e0e0e0;
 }
 
-dl:after {
+dl.plugin_definitionlist:after {
   content: '.';
   display: block;
   clear: both;
@@ -20,40 +20,36 @@ dl:after {
   visibility: hidden;
 }
 
-dt {
+dl.plugin_definitionlist dt {
   clear: left;
   margin-top: 0.5em;
 }
 
-dt+dt {
+dl.plugin_definitionlist dt+dt {
   margin-top: 0;
 }
 
-dd+dt {
+dl.plugin_definitionlist dd+dt {
   border-top: 1px dashed #e0e0e0;
   padding-top: 0.5em;
 }
 
-dt span.term {
+dl.plugin_definitionlist dt span.term {
   float: left;
   width: 10em;
 }
 
-dd {
+dl.plugin_definitionlist dd {
   margin-left: 10.3em;
   padding-left: 0.8em;
   background: url(images/bullet.gif) no-repeat 0 0.4em;
 }
- 
-dd p {
+
+dl.plugin_definitionlist dd p {
   margin: 0;
   padding: 0;
 }
 
-* html dl { height: 1px; }
-
-/* reset above style to prevent messing up plugin manager */
-#plugin_manager dd { background-image: none;}
-
+* html dl.plugin_definitionlist { height: 1px; }
 
 /* end plugin: definitionlist */

--- a/syntax.php
+++ b/syntax.php
@@ -44,6 +44,13 @@ if (!defined('DL_DD')) define('DL_DD', ':');     // character to indicate a defi
 // - set to false or 0 to use simple list html
 // - set to true or 1 to wrap the term element between <span class="term"> and </span>;
 
+// $this->getConf('stylename') : default = 'plugin_definitionlist'
+// class name applyed to dl tag
+// - set blank to use simple list html <dl> ... </dl>
+// - set stylename to apply style rule to dl like <dl class="stylename"> ... </dl>
+// The default stylename is defined in css files bundled.
+// Your own class should be defined in conf/userstyle.css file.
+
 // -----------------------------------------------------------------
 
 /**
@@ -137,7 +144,9 @@ class syntax_plugin_definitionlist extends DokuWiki_Syntax_Plugin {
 
         switch ( $state ) {
           case DOKU_LEXER_ENTER:
-            $renderer->doc .= "\n<dl>\n";
+            $class = ($this->getConf('stylename')) ?
+                ' class="'.$this->getConf('stylename').'"' : '';
+            $renderer->doc .= "\n<dl".$class.">\n";
             $renderer->doc .= $this->_open($param);
             break;
           case DOKU_LEXER_MATCHED:

--- a/syntax.php
+++ b/syntax.php
@@ -37,11 +37,12 @@ require_once(DOKU_PLUGIN.'syntax.php');
 if (!defined('DL_DT')) define('DL_DT', ';');     // character to indicate a term (dt)
 if (!defined('DL_DD')) define('DL_DD', ':');     // character to indicate a definition (dd)
 
-// define the html used to generate the definition list
-// - set to false or 0 to use simple list html <dl><dt>term</dt><dd>definition</dd> ... </dl>
-// - set to true or 1 to use wrap the term element in a span permitting more complex styling
-//   <dl><dt><span class='term'>term</span></dt><dd>definition</dd> ... </dl>
-if (!defined('DL_FANCY')) define('DL_FANCY', true);
+// ---------- [ Optional config parameters ] ------------------------
+
+// $this->getConf('dt_fancy') : default = false
+// additional markup for term element (dt tag)
+// - set to false or 0 to use simple list html
+// - set to true or 1 to wrap the term element between <span class="term"> and </span>;
 
 // -----------------------------------------------------------------
 
@@ -199,7 +200,7 @@ class syntax_plugin_definitionlist extends DokuWiki_Syntax_Plugin {
      */
     function _open($tag) {
         array_push($this->stack, $tag);
-        $wrap = (DL_FANCY && $tag == 'dt') ? "<span class='term'>" : "";
+        $wrap = ($this->getConf('dt_fancy') && $tag == 'dt') ? "<span class='term'>" : "";
         return "<$tag>$wrap";
     }
 
@@ -209,7 +210,7 @@ class syntax_plugin_definitionlist extends DokuWiki_Syntax_Plugin {
      */
     function _close() {
         $tag = array_pop($this->stack);
-        $wrap = (DL_FANCY && $tag == 'dt') ? "</span>" : "";
+        $wrap = ($this->getConf('dt_fancy') && $tag == 'dt') ? "</span>" : "";
         return "$wrap</$tag>\n";
     }
 

--- a/syntax.php
+++ b/syntax.php
@@ -56,17 +56,6 @@ class syntax_plugin_definitionlist extends DokuWiki_Syntax_Plugin {
     /**
      * return some info
      */
-    function getInfo(){
-        return array(
-            'author' => 'Christopher Smith',
-            'email'  => 'chris@jalakai.co.uk',
-            'date'   => '2008-08-13',
-            'name'   => 'Definition list plugin',
-            'desc'   => 'Add HTML style definition list '.DL_DT.' term '.DL_DD.' definition',
-            'url'    => 'http://www.dokuwiki.org/plugin:definitionlist',
-        );
-    }
-
     function getType() { return 'container'; }
     function getAllowedTypes() { return array('container','substition','protected','disabled','formatting'); }
     function getPType() { return 'block'; }          // block, so not surrounded by <p> tags


### PR DESCRIPTION
The definitionlist plugin does not set any class name to the dl element, and style rules defined in the style.css in the plugin directory may affect rules with my own rules in the conf/userstyle.css for dl, dt, dd elements. This makes me difficult to define user own rules for the definition list. This request contains three commits, of two are to increase css flexibility of the definitionlist plugin:
- plugin config variable "stylename" for dl element
- use plugin config variable "dt_fancy" instead of DL_FANCY

The admin can set appropriate value through the Configuration manager. Language files prepared for English and Japanese. This request also contains removal of old function getInfo() replaced by plugin.info.txt file since DokuWIki 2009-12-25 Lemming.

Thanks for your setup gitHub repository of the definitionlist plugin for better source accessibility.

Satoshi
