### PR TITLE
bugfix defalut value for dt_fancy

### DIFF
--- a/_test/syntax.test.php
+++ b/_test/syntax.test.php
@@ -99,7 +99,7 @@ class plugin_definitionlist_syntax_test extends DokuWikiTest {
 
     function test_nonfancy() {
         global $conf;
-        $conf['plugin']['definitionlist']['dt_fancy'] = false;
+        $conf['plugin']['definitionlist']['dt_fancy'] = 0;
 
         $in1 = NL.'  ; Term'.NL
                  .'  : Definition'.NL;

--- a/conf/default.php
+++ b/conf/default.php
@@ -3,5 +3,5 @@
  * Default settings for the definitionlist plugin
  */
 
-$conf['dt_fancy']  = true;
+$conf['dt_fancy']  = 1; // default on
 $conf['classname'] = 'plugin_definitionlist';


### PR DESCRIPTION
The `onoff` type configuration metadata must be **1** or **0**. 
This should fix issue #6, the value change wont be saved in the Config Manager.
