### PR TITLE
Added/adjusted ODT support for ODT redesign branch.

### DIFF
--- a/_test/syntax.test.php
+++ b/_test/syntax.test.php
@@ -99,7 +99,7 @@ class plugin_definitionlist_syntax_test extends DokuWikiTest {
 
     function test_nonfancy() {
         global $conf;
-        $conf['plugin']['definitionlist']['dt_fancy'] = false;
+        $conf['plugin']['definitionlist']['dt_fancy'] = 0;
 
         $in1 = NL.'  ; Term'.NL
                  .'  : Definition'.NL;

--- a/conf/default.php
+++ b/conf/default.php
@@ -3,5 +3,5 @@
  * Default settings for the definitionlist plugin
  */
 
-$conf['dt_fancy']  = true;
+$conf['dt_fancy']  = 1; // default on
 $conf['classname'] = 'plugin_definitionlist';

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base    definitionlist
-author  Chris Smith
+author  Chris Smith, LarsDW223
 email   chris@jalakai.co.uk
-date    2014-06-06
+date    2016-09-15
 name    Definition List plugin
 desc    Add syntax for definition lists.
-url     http://www.dokuwiki.org/plugin:definitionlist
+url     https://www.dokuwiki.org/plugin:definitionlist

--- a/syntax.php
+++ b/syntax.php
@@ -336,20 +336,28 @@ class syntax_plugin_definitionlist extends DokuWiki_Syntax_Plugin {
                 $renderer->createTextStyle($parent_properties);
             }
 
-            $state = new helper_plugin_odt_cssdocument();
-            $state->open('dl', 'class="plugin_definitionlist"', NULL, NULL);
-            $state->open('dd', NULL, NULL, NULL);
+            // Get the current HTML stack from the ODT renderer
+            $stack = $renderer->getHTMLStack ();
+
+            // Save state to restore it later
+            $state = array();
+            $stack->getState ($state);
+            // Only for debugging ==> see end of this function
+            //$renderer->dumpHTMLStack ();
+
+            $stack->open('dl', 'class="plugin_definitionlist"', NULL, NULL);
+            $stack->open('dd', NULL, NULL, NULL);
 
             // Get CSS properties for ODT export.
             $dd_properties = array ();
-            $renderer->getODTPropertiesFromElement ($dd_properties, $state->getCurrentElement(), 'screen', true);
+            $renderer->getODTPropertiesFromElement ($dd_properties, $stack->getCurrentElement(), 'screen', true);
 
-            $state->close('dd');
-            $state->open('dt', NULL, NULL, NULL);
+            $stack->close('dd');
+            $stack->open('dt', NULL, NULL, NULL);
 
             // Get CSS properties for ODT export.
             $dt_properties = array ();
-            $renderer->getODTPropertiesFromElement ($dt_properties, $state->getCurrentElement(), 'screen', true);
+            $renderer->getODTPropertiesFromElement ($dt_properties, $stack->getCurrentElement(), 'screen', true);
 
             // Set style data to be returned to caller
             $style_data ['border-bottom'] = $dt_properties ['border-top'];
@@ -373,8 +381,11 @@ class syntax_plugin_definitionlist extends DokuWiki_Syntax_Plugin {
             $dd_properties ['style-display-name'] = 'Description';
             $dd_properties ['background'] = NULL;
             $renderer->createTextStyle($dd_properties);
-            
-            unset($state);
+
+            $stack->restoreState ($state);
+            // Only for debugging to check if the ODT plugins HTML stack
+            // is restored to the start state
+            //$renderer->dumpHTMLStack ();
 
             $do_once = false;
         }

--- a/syntax.php
+++ b/syntax.php
@@ -166,7 +166,7 @@ class syntax_plugin_definitionlist extends DokuWiki_Syntax_Plugin {
      * create output for the xhtml renderer
      *
      */
-    protected function render_xhtml(&$renderer, $data) {
+    protected function render_xhtml(Doku_Renderer $renderer, $data) {
         list($tag,$state,$match) = $data;
 
         switch ( $state ) {
@@ -189,7 +189,7 @@ class syntax_plugin_definitionlist extends DokuWiki_Syntax_Plugin {
      *
      * @author:   Gabriel Birke <birke@d-scribe.de>
      */
-    protected function render_odt_old(&$renderer, $data) {
+    protected function render_odt_old(Doku_Renderer $renderer, $data) {
         static $param_styles = array('dd' => 'def_f5_list', 'dt' => 'def_f5_term');
         $this->_set_odt_styles_old($renderer);
 
@@ -223,7 +223,7 @@ class syntax_plugin_definitionlist extends DokuWiki_Syntax_Plugin {
      * Create output for ODT renderer (newer version)
      * @author: LarsDW223
      */
-    protected function render_odt_new(&$renderer, $data) {
+    protected function render_odt_new(Doku_Renderer $renderer, $data) {
         static $style_data = array();
         $this->_set_odt_styles_new($renderer, $style_data);
 
@@ -296,7 +296,7 @@ class syntax_plugin_definitionlist extends DokuWiki_Syntax_Plugin {
      * @param  $renderer    current (odt) renderer object
      * @return void
      */
-    protected function _set_odt_styles_old(&$renderer) {
+    protected function _set_odt_styles_old(Doku_Renderer $renderer) {
         static $do_once = true;
 
         if ($do_once) {


### PR DESCRIPTION
I added ODT support for the branch redesign of the ODT plugin.
With this changes and that branch of the ODT plugin the ODT export is very close to the HTML look.
The style for the text spans is visible in LibreOffice and can be modified by the user.

Please check and merge.
